### PR TITLE
CI tweaks for tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Node was added to allow frontend builds without needing another container or ext
 
 Tagging was designed to allow easy pinning to versions of Ubuntu, Python and Node that are in LTS support from their respective organisations, while accepting security and patch updates.
 
-The Dockerfile was written to allow the same file to be used across multiple versions with slightly differning requirements (e.g. using extra apt repositories for python) for easier maintenance, at the expense of build caching.
+The Dockerfile was written to allow the same file to be used across multiple versions with slightly differning requirements (e.g. using extra apt repositories for python) for easier maintenance, at the expense of build caching. The script has been written to make use of multiple threads / cores for optimum efficiency.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  script: ./build-all.sh gcr.io/sre-docker-registry/py-node $SHA-$ID
+  script: ./build-all.sh gcr.io/sre-docker-registry/py-node ${SHA:0:12}-$ID
   env:
   - 'SHA=$COMMIT_SHA'
   - 'ID=$BUILD_ID'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,8 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  script: ./build-all.sh gcr.io/sre-docker-registry/py-node ${SHA:0:12}-$ID
+  script: |
+    #!/usr/bin/env bash
+    ./build-all.sh gcr.io/sre-docker-registry/py-node ${SHA:0:12}-$ID
   env:
   - 'SHA=$COMMIT_SHA'
   - 'ID=$BUILD_ID'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   script: ./build-all.sh gcr.io/sre-docker-registry/py-node $SHA-$ID
   env:
-  - 'SHA=${COMMIT_SHA:0:10}'
+  - 'SHA=$COMMIT_SHA'
   - 'ID=$BUILD_ID'
 images: ['gcr.io/sre-docker-registry/py-node']
 timeout: 3h

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   script: |
     #!/usr/bin/env bash
-    ./build-all.sh gcr.io/sre-docker-registry/py-node ${SHA:0:12}-$ID
+    ./build-all.sh gcr.io/sre-docker-registry/py-node ${SHA:0:8}-${ID:0:8}
   env:
   - 'SHA=$COMMIT_SHA'
   - 'ID=$BUILD_ID'


### PR DESCRIPTION
fixed a tagging issue so each image gets tagged with all general tags plus git commit and build ID, both truncated to 8 chars